### PR TITLE
Proposal about elisp code vs customization menu

### DIFF
--- a/README.org
+++ b/README.org
@@ -210,14 +210,14 @@ changes out-of-the-box ([[#h:2bb57369-352a-43bf-afe3-0bed2fcc7359][Extra tweaks]
   everything is buffer-local, so it is possible to use file variables as
   described in the Emacs manual.
 
-+ If you want to use outlines instead of page breaks (the ^L)
++ If you want to use outlines instead of page breaks (the ^L).
   Set in the configuration menu:
   - Logos Outlines Are Pages
     (When non-nil, every outline heading is a page delimiter)
   - Logos Outline Regexp Alist
     (Alist of major mode and regular expression of the outline)
 
-+ If you want to nil hide the modeline
++ If you want to hide the modeline.
   Set in the configuration menu:
   - Logos Hide Mode Line
   

--- a/README.org
+++ b/README.org
@@ -228,8 +228,7 @@ changes out-of-the-box ([[#h:2bb57369-352a-43bf-afe3-0bed2fcc7359][Extra tweaks]
 
 ;; These apply when `logos-focus-mode' is enabled.  Their value is
 ;; buffer-local.
-(setq-default logos-hide-mode-line t
-              logos-hide-buffer-boundaries t
+(setq-default logos-hide-buffer-boundaries t
               logos-hide-fringe t
               logos-variable-pitch nil
               logos-buffer-read-only nil

--- a/README.org
+++ b/README.org
@@ -219,7 +219,7 @@ changes out-of-the-box ([[#h:2bb57369-352a-43bf-afe3-0bed2fcc7359][Extra tweaks]
 
 + If you want to nil hide the modeline
   Set in the configuration menu:
-  - Logos Hide Mode Line: on (non-nil)
+  - Logos Hide Mode Line
   
   etc.
         

--- a/README.org
+++ b/README.org
@@ -210,16 +210,21 @@ changes out-of-the-box ([[#h:2bb57369-352a-43bf-afe3-0bed2fcc7359][Extra tweaks]
   everything is buffer-local, so it is possible to use file variables as
   described in the Emacs manual.
 
++ If you want to use outlines instead of page breaks (the ^L)
+  Set in the configuration menu:
+  - Logos Outlines Are Pages
+    (When non-nil, every outline heading is a page delimiter)
+  - Logos Outline Regexp Alist
+    (Alist of major mode and regular expression of the outline)
+
++ If you want to nil hide the modeline
+  Set in the configuration menu:
+  - Logos Hide Mode Line: on (non-nil)
+  
+  etc.
+        
 #+begin_src emacs-lisp
 (require 'logos)
-
-;; If you want to use outlines instead of page breaks (the ^L)
-(setq logos-outlines-are-pages t)
-(setq logos-outline-regexp-alist
-      `((emacs-lisp-mode . "^;;;+ ")
-        (org-mode . "^\\*+ +")
-        (markdown-mode . "^\\#+ +")
-        (t . ,(or outline-regexp logos--page-delimiter))))
 
 ;; These apply when `logos-focus-mode' is enabled.  Their value is
 ;; buffer-local.


### PR DESCRIPTION
The variables that can be set in the customization menu, maybe shouldn't appear as elisp code in the section "4 Sample Configuration". Because it is possible that the user copies that configuration from the elisp code into the init file, and when she tries to customize logos using the customization menu (maybe months later), the changes in the customization menu are "crushed" by the previously pasted elisp code.

I haven't made all the changes, just an example of my proposal.